### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,5 +1,9 @@
 name: Build and Push Docker Image to GitHub Container Registry
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Mathsterk/onlyfoxes/security/code-scanning/1](https://github.com/Mathsterk/onlyfoxes/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly specify the minimal required permissions for the GITHUB_TOKEN. Since the workflow checks out code (requiring `contents: read`) and pushes Docker images to the GitHub Container Registry (requiring `packages: write`), these two permissions should be set. The `permissions` block can be added at the top level of the workflow file (applies to all jobs), or at the job level (applies only to the `build` job). The best practice is to add it at the top level unless different jobs require different permissions. The change should be made at the top of `.github/workflows/docker-build.yml`, after the `name:` line and before the `on:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
